### PR TITLE
Fixed api.windows to check if 'name' doesn't exist

### DIFF
--- a/api/windows.py
+++ b/api/windows.py
@@ -26,7 +26,7 @@ def get_process_info():
         process_name = element['processName']
         for process in psutil.process_iter():
             process_info = process.as_dict(attrs=['pid', 'name'])
-            if process_info['name'].lower() in process_name:
+            if process_info.get('name') and process_info.get('name').lower() in process_name:
                 element['pid'] = process_info['pid']
                 return element
 


### PR DESCRIPTION
At the end of the dictionary, something get's spit out that doesn't contain `name`, so it crashes towards the end of the for loop.

Closes #26 